### PR TITLE
fix: add_policy at enforcer server hasn't handled a case where new_enforce comes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,9 @@ p = sub, obj, act
 [policy_effect]
 e = some(where (p.eft == allow))
 
-# The function named `regex_match?` will be defined later in code.
+# The function named `match?` will be defined later in code.
 [matchers]
-m = r.sub == p.sub && regex_match?(r.obj, p.obj) && regex_match?(r.act, p.act)
+m = r.sub == p.sub && match?(r.obj, p.obj) && match?(r.act, p.act)
 ```
 
 Policy rules `restful_ac.csv`:

--- a/README.md
+++ b/README.md
@@ -227,9 +227,9 @@ p = sub, obj, act
 [policy_effect]
 e = some(where (p.eft == allow))
 
-# The function named `match?` will be defined later in code.
+# The function named `regex_match?` will be defined later in code.
 [matchers]
-m = r.sub == p.sub && match?(r.obj, p.obj) && match?(r.act, p.act)
+m = r.sub == p.sub && regex_match?(r.obj, p.obj) && regex_match?(r.act, p.act)
 ```
 
 Policy rules `restful_ac.csv`:

--- a/lib/acx/enforcer_server.ex
+++ b/lib/acx/enforcer_server.ex
@@ -159,6 +159,9 @@ defmodule Acx.EnforcerServer do
       {:ok, new_enforcer} ->
         :ets.insert(:enforcers_table, {self_name(), new_enforcer})
         {:reply, :ok, new_enforcer}
+      new_enforcer ->
+        :ets.insert(:enforcers_table, {self_name(), new_enforcer})
+        {:reply, :ok, new_enforcer}
     end
   end
 

--- a/lib/acx/enforcer_server.ex
+++ b/lib/acx/enforcer_server.ex
@@ -134,6 +134,9 @@ defmodule Acx.EnforcerServer do
       {:ok, new_enforcer} ->
         :ets.insert(:enforcers_table, {self_name(), new_enforcer})
         {:reply, :ok, new_enforcer}
+      new_enforcer ->
+        :ets.insert(:enforcers_table, {self_name(), new_enforcer})
+        {:reply, :ok, new_enforcer}
     end
   end
 


### PR DESCRIPTION
Added the case in which it is only received is schema of the Enforcer.
This solves the following error `(CaseClauseError) no case clause matching:% Acx.Enforcer {.....}` since if you try to add a policy, the following results are obtained:
![Captura de pantalla de 2021-06-14 22-49-02](https://user-images.githubusercontent.com/53799471/121990036-bdd0d100-cd62-11eb-85ac-5b4d91c945ae.png)

