### PR TITLE
feat: add nested struct support to matcher

### DIFF
--- a/lib/acx/model.ex
+++ b/lib/acx/model.ex
@@ -70,15 +70,15 @@ defmodule Acx.Model do
       ...> %Model{matcher: %Matcher{prog: prog}} = m
       ...> prog
       [
-        {:fetch_attr, %{attr: :sub, key: :r}},
-        {:fetch_attr, %{attr: :sub, key: :p}},
+        {:fetch_attr, %{attr: [:sub], key: :r}},
+        {:fetch_attr, %{attr: [:sub], key: :p}},
         {:eq},
-        {:fetch_attr, %{attr: :obj, key: :r}},
-        {:fetch_attr, %{attr: :obj, key: :p}},
+        {:fetch_attr, %{attr: [:obj], key: :r}},
+        {:fetch_attr, %{attr: [:obj], key: :p}},
         {:eq},
         {:and},
-        {:fetch_attr, %{attr: :act, key: :r}},
-        {:fetch_attr, %{attr: :act, key: :p}},
+        {:fetch_attr, %{attr: [:act], key: :r}},
+        {:fetch_attr, %{attr: [:act], key: :p}},
         {:eq},
         {:and}
       ]

--- a/lib/acx/model/matcher.ex
+++ b/lib/acx/model/matcher.ex
@@ -47,15 +47,15 @@ defmodule Acx.Model.Matcher do
       ...> %Matcher{prog: prog} = Matcher.new(m)
       ...> prog
       [
-        {:fetch_attr, %{key: :r, attr: :sub}},
-        {:fetch_attr, %{key: :p, attr: :sub}},
+        {:fetch_attr, %{key: :r, attr: [:sub]}},
+        {:fetch_attr, %{key: :p, attr: [:sub]}},
         {:eq},
-        {:fetch_attr, %{key: :r, attr: :obj}},
-        {:fetch_attr, %{key: :p, attr: :obj}},
+        {:fetch_attr, %{key: :r, attr: [:obj]}},
+        {:fetch_attr, %{key: :p, attr: [:obj]}},
         {:eq},
         {:and},
-        {:fetch_attr, %{key: :r, attr: :act}},
-        {:fetch_attr, %{key: :p, attr: :act}},
+        {:fetch_attr, %{key: :r, attr: [:act]}},
+        {:fetch_attr, %{key: :p, attr: [:act]}},
         {:eq},
         {:and}
       ]
@@ -64,15 +64,15 @@ defmodule Acx.Model.Matcher do
       ...> %Matcher{prog: prog} = Matcher.new(m)
       ...> prog
       [
-        {:fetch_attr, %{attr: :sub, key: :r}},
-        {:fetch_attr, %{attr: :sub, key: :p}},
+        {:fetch_attr, %{attr: [:sub], key: :r}},
+        {:fetch_attr, %{attr: [:sub], key: :p}},
         {:eq},
-        {:fetch_attr, %{attr: :obj, key: :r}},
-        {:fetch_attr, %{attr: :obj, key: :p}},
+        {:fetch_attr, %{attr: [:obj], key: :r}},
+        {:fetch_attr, %{attr: [:obj], key: :p}},
         {:call, %{arity: 2, name: :regex_match?}},
         {:and},
-        {:fetch_attr, %{attr: :act, key: :r}},
-        {:fetch_attr, %{attr: :act, key: :p}},
+        {:fetch_attr, %{attr: [:act], key: :r}},
+        {:fetch_attr, %{attr: [:act], key: :p}},
         {:call, %{arity: 2, name: :regex_match?}},
         {:and}
       ]
@@ -81,15 +81,15 @@ defmodule Acx.Model.Matcher do
       ...> %Matcher{prog: prog} = Matcher.new(m)
       ...> prog
       [
-        {:fetch_attr, %{attr: :sub, key: :r}},
-        {:fetch_attr, %{attr: :sub, key: :p}},
+        {:fetch_attr, %{attr: [:sub], key: :r}},
+        {:fetch_attr, %{attr: [:sub], key: :p}},
         {:call, %{arity: 2, name: :g}},
-        {:fetch_attr, %{attr: :obj, key: :r}},
-        {:fetch_attr, %{attr: :obj, key: :p}},
+        {:fetch_attr, %{attr: [:obj], key: :r}},
+        {:fetch_attr, %{attr: [:obj], key: :p}},
         {:call, %{arity: 2, name: :g2}},
         {:and},
-        {:fetch_attr, %{attr: :act, key: :r}},
-        {:fetch_attr, %{attr: :act, key: :p}},
+        {:fetch_attr, %{attr: [:act], key: :r}},
+        {:fetch_attr, %{attr: [:act], key: :p}},
         {:eq},
         {:and}
       ]
@@ -98,18 +98,18 @@ defmodule Acx.Model.Matcher do
       ...> %Matcher{prog: prog} = Matcher.new(m)
       ...> prog
       [
-        {:fetch_attr, %{attr: :sub, key: :r}},
-        {:fetch_attr, %{attr: :sub, key: :p}},
+        {:fetch_attr, %{attr: [:sub], key: :r}},
+        {:fetch_attr, %{attr: [:sub], key: :p}},
         {:eq},
-        {:fetch_attr, %{attr: :obj, key: :r}},
-        {:fetch_attr, %{attr: :obj, key: :p}},
-        {:eq},
-        {:and},
-        {:fetch_attr, %{attr: :act, key: :r}},
-        {:fetch_attr, %{attr: :act, key: :p}},
+        {:fetch_attr, %{attr: [:obj], key: :r}},
+        {:fetch_attr, %{attr: [:obj], key: :p}},
         {:eq},
         {:and},
-        {:fetch_attr, %{attr: :sub, key: :r}},
+        {:fetch_attr, %{attr: [:act], key: :r}},
+        {:fetch_attr, %{attr: [:act], key: :p}},
+        {:eq},
+        {:and},
+        {:fetch_attr, %{attr: [:sub], key: :r}},
         {:push, "root"},
         {:eq},
         {:or}
@@ -328,7 +328,14 @@ defmodule Acx.Model.Matcher do
     [%{token: :dot} | rest],
     [{:var, attr}, {:var, key} | stack]
   ) do
-    convert_from_postfix(rest, [{:dot, key, attr} | stack])
+    convert_from_postfix(rest, [{:dot, key, [attr]} | stack])
+  end
+
+  defp convert_from_postfix(
+    [%{token: :dot} | rest],
+    [{:var, next_attr}, {:dot, key, attrs} | stack]
+  ) do
+    convert_from_postfix(rest, [{:dot, key, attrs ++ [next_attr]} | stack])
   end
 
   # For anything else, we consider it's a syntax error.
@@ -425,7 +432,7 @@ defmodule Acx.Model.Matcher do
         {:error, :key_not_found}
 
       attrs ->
-        case attrs[a] do
+        case get_in(attrs, a) do
           nil ->
             {:error, :attribute_not_found}
 

--- a/test/model/matcher_test.exs
+++ b/test/model/matcher_test.exs
@@ -2,4 +2,15 @@ defmodule Acx.Model.MatcherTest do
   use ExUnit.Case, async: true
   alias Acx.Model.Matcher
   doctest Acx.Model.Matcher
+
+  describe "nested structs" do
+    test "/" do
+      m = Acx.Model.Matcher.new("r.sub.key == p.sub.id.key")
+      r1 = %{sub: %{key: 1}}
+      p1 = %{sub: %{id: %{key: 1}}}
+      p2 = %{sub: %{id: %{key: 2}}}
+      assert !!Acx.Model.Matcher.eval!(m, %{p: p1, r: r1})
+      refute !!Acx.Model.Matcher.eval!(m, %{p: p2, r: r1})
+    end
+  end
 end


### PR DESCRIPTION
Since we have maps support in request, we want to use it in matcher expression or custom functions, these changes add this feature