### PR TITLE
fix: g3 matcher function + tests

### DIFF
--- a/lib/acx/enforcer_server.ex
+++ b/lib/acx/enforcer_server.ex
@@ -91,7 +91,7 @@ defmodule Acx.EnforcerServer do
   def add_mapping_policy(ename, {mapping_name, role1, role2, dom}) do
     GenServer.call(
       via_tuple(ename),
-      {:add_mapping_policy, {mapping_name, role1, role2 <> dom}}
+      {:add_mapping_policy, {mapping_name, role1, role2, dom}}
     )
   end
 

--- a/test/data/g3_with_domain.conf
+++ b/test/data/g3_with_domain.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, dom, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[role_definition]
+g = _, _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = (g(r.sub, p.sub, r.dom) || g(r.sub, p.sub, "*")) && keyMatch2(r.obj, p.obj) && r.act == p.act

--- a/test/data/g3_with_domain.csv
+++ b/test/data/g3_with_domain.csv
@@ -1,0 +1,8 @@
+p, admin, /data/organizations/:orgid/, GET
+p, admin, /data/organizations/:orgid/, POST
+p, user, /data/organizations/:orgid/, GET
+
+g, alice, admin, *
+g, bob, admin, 1
+g, peter, admin, 2
+g, john, user, 2

--- a/test/enforcer/g3_with_domain_test.exs
+++ b/test/enforcer/g3_with_domain_test.exs
@@ -1,0 +1,64 @@
+defmodule Acx.Enforcer.G3WithDomain do
+  use ExUnit.Case, async: true
+  alias Acx.Enforcer
+
+  @cfile "../data/g3_with_domain.conf" |> Path.expand(__DIR__)
+  @pfile "../data/g3_with_domain.csv" |> Path.expand(__DIR__)
+
+  setup do
+    {:ok, e} = Enforcer.init(@cfile)
+
+    e =
+      e
+      |> Enforcer.load_policies!(@pfile)
+      |> Enforcer.load_mapping_policies!(@pfile)
+
+    {:ok, e: e}
+  end
+
+  describe "allow?/2" do
+    @test_cases [
+      {["alice", "1", "/data/organizations/1/", "GET"], true},
+      {["alice", "1", "/data/organizations/1/", "POST"], true},
+      {["alice", "2", "/data/organizations/2/", "GET"], true},
+      {["alice", "2", "/data/organizations/2/", "POST"], true},
+      {["alice", "3", "/data/organizations/3/", "GET"], true},
+      {["alice", "3", "/data/organizations/3/", "POST"], true},
+      {["alice", "1", "/data/organizations/1/", "no_existing"], false},
+
+      {["alice", "1", "no_existing", "GET"], false},
+      {["bob", "1", "/data/organizations/1/", "GET"], true},
+      {["bob", "1", "/data/organizations/1/", "POST"], true},
+      {["bob", "2", "/data/organizations/2/", "GET"], false},
+      {["bob", "2", "/data/organizations/2/", "POST"], false},
+      {["bob", "3", "/data/organizations/3/", "GET"], false},
+      {["bob", "3", "/data/organizations/3/", "POST"], false},
+      {["bob", "1", "/data/organizations/1/", "no_existing"], false},
+      {["bob", "1", "no_existing", "GET"], false},
+
+      {["peter", "1", "/data/organizations/1/", "GET"], false},
+      {["peter", "1", "/data/organizations/1/", "POST"], false},
+      {["peter", "2", "/data/organizations/2/", "GET"], true},
+      {["peter", "2", "/data/organizations/2/", "POST"], true},
+      {["peter", "3", "/data/organizations/3/", "GET"], false},
+      {["peter", "3", "/data/organizations/3/", "POST"], false},
+      {["peter", "1", "/data/organizations/1/", "no_existing"], false},
+      {["peter", "1", "no_existing", "GET"], false},
+
+      {["john", "1", "/data/organizations/1/", "GET"], false},
+      {["john", "1", "/data/organizations/1/", "POST"], false},
+      {["john", "2", "/data/organizations/2/", "GET"], true},
+      {["john", "2", "/data/organizations/2/", "POST"], false},
+      {["john", "3", "/data/organizations/3/", "GET"], false},
+      {["john", "3", "/data/organizations/3/", "POST"], false},
+      {["john", "1", "/data/organizations/1/", "no_existing"], false},
+      {["john", "1", "no_existing", "GET"], false}
+    ]
+
+    Enum.each(@test_cases, fn {req, res} ->
+      test "response `#{res}` for request #{inspect(req)}", %{e: e} do
+        assert e |> Enforcer.allow?(unquote(req)) === unquote(res)
+      end
+    end)
+  end
+end


### PR DESCRIPTION
Fix an issue where [add_mapping_policies/2](https://github.com/casbin/casbin-ex/blob/master/lib/acx/enforcer_server.ex#L91) is never called because if [this](https://github.com/casbin/casbin-ex/blob/master/lib/acx/enforcer_server.ex#L94).

I also added some tests for this.