### PR TITLE
feat: add reset_enforcer/2

### DIFF
--- a/lib/acx/enforcer_server.ex
+++ b/lib/acx/enforcer_server.ex
@@ -217,4 +217,22 @@ defmodule Acx.EnforcerServer do
     end
   end
 
+  # If an existing enforcer is found, replace it with a fresh one.
+  def reset_enforcer(ename, cfile) do
+    case :ets.lookup(:enforcers_table, ename) do
+      [] ->
+        {:error, "error occurred when resetting enforcer #{ename}: not existing"}
+
+      [{^ename, _}] ->
+        case Enforcer.init(cfile) do
+          {:error, reason} ->
+            {:error, reason}
+
+          {:ok, enforcer} ->
+            :ets.insert(:enforcers_table, {ename, enforcer})
+            {:ok, enforcer}
+        end
+    end
+  end
+
 end


### PR DESCRIPTION
Adding a new feature to reset an **enforcer** to its _initial state_.

Why? Actually I need this feature because there is no way to remove a policy once it has been added. I will try add a proper function to `Acx.Internal.RoleGroup` later, to handle such behavior without having to wipe the whole configuration. But right now I don't have much time to dive into this.

Edit: nvm, it should obviously be done in another way.